### PR TITLE
Dealing with lack of title in olcao.skl

### DIFF
--- a/src/scripts/makeinput
+++ b/src/scripts/makeinput
@@ -1313,6 +1313,14 @@ sub initializeCell
    # Get the system title.
    $systemTitle_ref = StructureControl::getSystemTitleRef();
 
+   # if the system does not have an explicit title, it could cause some
+   # issues down the line. in order to fix this, the default 
+   # systemTitle above is "empty". So, in order to catch such cases we need
+   # to add a newline ("\n") to the title. In order to not mess up the 
+   # cases where a title WAS given, we will chomp first then add a
+   # newline.
+   $systemTitle_ref = chomp($systemTitle_ref) + "\n";
+
    # Retrieve references to useful structural data.
    $realLattice_ref    = StructureControl::getRealLatticeRef();
    $realLatticeInv_ref = StructureControl::getRealLatticeInvRef();


### PR DESCRIPTION
There is an issue when the user forgets to add in an explicit title
to the olcao.skl file. i.e. the file starts with

title
end
cell
....

in such cases, the input files are generated incorrectly. I changed the
makeinput script to handle such cases gracefully.
